### PR TITLE
UrlMappings causes problems in application using iCalendar plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,3 +81,8 @@ bintray {
         }
     }
 }
+
+jar {
+    exclude '/UrlMappings*'
+    exclude '/TestController*'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 plugins {
-    id "io.spring.dependency-management" version "0.5.2.RELEASE"
+    id "io.spring.dependency-management" version "0.6.1.RELEASE"
     id "com.jfrog.bintray" version "1.6"
 }
 

--- a/src/main/groovy/ch/silviowangler/grails/icalender/ICalendarGrailsPlugin.groovy
+++ b/src/main/groovy/ch/silviowangler/grails/icalender/ICalendarGrailsPlugin.groovy
@@ -13,7 +13,8 @@ class ICalendarGrailsPlugin extends Plugin {
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
             'grails-app/views/error.gsp',
-            'grails-app/controllers/TestController.groovy'
+            'TestController',
+            'UrlMappings'
     ]
 
     def author = "Silvio Wangler"


### PR DESCRIPTION
Grails create mapping rules according to all UrlMappings in the application (incl. dependencies). We use customized url mappings in our application and some mappings are incorrect since we added iCalendar plugin to our application, because the UrlMappings from iCalendar plugin are used by the mapper as well and are in conflict with our definitions.

Based on https://github.com/grails/grails-core/issues/9706 and http://docs.grails.org/3.1.1/guide/plugins.html#providingBasicArtefacts I mean that the UrlMappings.groovy shouldn't be included into the generated jar of your plugin.